### PR TITLE
fix: 빌드 설정 간소화 및 TypeScript 파서 옵션 개선

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,4 @@
 import plugin from './dist/index.js';
-import tseslint from 'typescript-eslint';
 
 export default [
   {
@@ -16,20 +15,5 @@ export default [
   ...plugin.configs.import,
   ...plugin.configs.javascript,
   ...plugin.configs.typescript,
-  ...plugin.configs.react,
-  {
-    files: ['**/*.{ts,cts,mts,tsx}'],
-    languageOptions: {
-      parser: tseslint.parser,
-      parserOptions: {
-        project: './tsconfig.eslint.json',
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-    rules: {
-      // 프로젝트 특정 오버라이드
-      '@typescript-eslint/no-explicit-any': 'off',
-      'no-console': 'off',
-    },
-  },
+  ...plugin.configs.react
 ];

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "vite build && tsc --emitDeclarationOnly",
+    "build": "vite build",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -40,10 +40,10 @@ describe('ESLint 플러그인 통합 테스트', () => {
         it('files 패턴이 지원하는 파일 확장자를 포함해야 한다', () => {
           const config = plugin.configs[configName];
 
-          config.forEach((conf: any) => {
+          config.forEach((conf: Linter.Config) => {
             if (conf.files) {
               expect(Array.isArray(conf.files)).toBe(true);
-              conf.files.forEach((pattern: string) => {
+              conf.files.forEach((pattern: string[] | string) => {
                 // 패턴이 glob 형식인지 확인
                 expect(pattern).toMatch(/\.(js|mjs|cjs|jsx|ts|mts|cts|tsx)|(\{[^}]+\})/);
               });
@@ -136,7 +136,7 @@ export default Component;
         if (configName === 'javascript') return; // javascript는 플러그인이 없음
 
         const config = plugin.configs[configName as keyof typeof plugin.configs];
-        const plugins = config.flatMap((conf: any) =>
+        const plugins = config.flatMap((conf: Linter.Config) =>
           conf.plugins ? Object.keys(conf.plugins) : [],
         );
 

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { ESLint } from 'eslint';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -7,6 +7,12 @@ export const typescriptConfig: Linter.Config[] = [
   {
     name: 'ukyi-config/typescript',
     files: ['**/*.{ts,cts,mts,tsx}'],
+    languageOptions: {
+      parser: ts.parser as Linter.Parser,
+      parserOptions: {
+        project: true,
+      },
+    },
     rules: {
       /* 빈 객체 타입 선언 허용 (type A = {}) */
       '@typescript-eslint/no-empty-object-type': 'off',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as url from 'url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { formatConfig } from './configs/format';
 import { importConfig } from './configs/import';
@@ -10,7 +10,7 @@ import { typescriptConfig } from './configs/typescript';
 
 import type { Plugin } from './types';
 
-const _filename = url.fileURLToPath(import.meta.url);
+const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
 const packageJson = JSON.parse(fs.readFileSync(path.join(_dirname, '..', 'package.json'), 'utf-8'));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["./src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [
     dts({
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/__tests__/**/*'],
       rollupTypes: true
     })
   ],
@@ -32,8 +32,9 @@ export default defineConfig({
         'fs',
         'url',
         'node:fs',
-        'node:path'
-      ]
+        'node:path',
+        'node:url'
+      ],
     },
     sourcemap: true,
     minify: false


### PR DESCRIPTION
## Summary
- 빌드 프로세스 간소화: `tsc --emitDeclarationOnly` 단계 제거 (vite-plugin-dts가 처리)
- TypeScript 설정 개선: 파서 옵션을 설정 파일에 직접 포함 (`project: true`)
- Node.js 내장 모듈 import 문 통일: `node:` 프리픽스 사용으로 표준화

## Changes
### 빌드 시스템
- `package.json`: 빌드 스크립트에서 별도 tsc 단계 제거
- `vite.config.ts`: external 모듈에 `node:url` 추가 및 테스트 파일 제외 패턴 개선

### TypeScript 설정
- `src/configs/typescript.ts`: 파서와 파서 옵션 직접 포함
- `tsconfig.json`: 테스트 파일 제외 규칙 간소화

### 코드 개선
- `src/index.ts`, `src/__tests__/typescript.test.ts`: Node.js 내장 모듈 import 표준화
- `src/__tests__/integration.test.ts`: ESLint 타입 정의 개선

### 프로젝트 설정
- `eslint.config.mjs`: 프로젝트 자체 ESLint 설정 간소화

## Test plan
- [x] 빌드 테스트: `pnpm build`
- [x] 타입 체크: `pnpm typecheck`
- [x] 유닛 테스트: `pnpm test`
- [ ] 배포 후 패키지 설치 및 사용 테스트