### PR TITLE
fix: React 버전 자동 감지 설정 추가

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -12,6 +12,15 @@ export const reactConfig: Linter.Config[] = [
   reactHooks.configs['recommended-latest'],
   jsxA11y.flatConfigs.recommended as Linter.Config,
   {
+    name: 'ukyi-config/react-settings',
+    settings: {
+      react: {
+        /* React 버전 자동 감지 */
+        version: 'detect',
+      },
+    },
+  },
+  {
     name: 'ukyi-config/react',
     files: ['**/*.{jsx,tsx}'],
     rules: {


### PR DESCRIPTION
## Summary
- eslint-plugin-react의 React 버전 경고 메시지 해결
- React 버전을 자동으로 감지하는 설정 추가

## Problem
외부 프로젝트에서 이 패키지를 사용할 때 다음과 같은 경고가 발생했습니다:
```
Warning: React version not specified in eslint-plugin-react settings
```

## Solution
`settings.react.version`을 `'detect'`로 설정하여 프로젝트의 React 버전을 자동으로 감지하도록 수정했습니다.

## Changes
- `src/configs/react.ts`에 React 버전 자동 감지 설정 추가
- 사용자가 별도로 React 버전을 설정할 필요 없음

## Test plan
- [x] 모든 테스트 통과 확인
- [x] React 프로젝트에서 경고 메시지가 사라지는지 확인